### PR TITLE
Fix: added is:inline directive and astro:before-swap listener

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,5 +1,5 @@
 ---
-
+import ThemeToggleBtn from "./ThemeToggleBtn.astro";
 ---
 
 <nav class="fixed w-full bg-white/80 dark:bg-gray-900/80 backdrop-blur-md z-50">
@@ -25,40 +25,7 @@
           >Showroom</a
         >
       </div>
-      <button
-        id="theme-toggle"
-        class="p-2 rounded-lg bg-gray-100 dark:bg-gray-800"
-      >
-        <svg
-          class="w-5 h-5 dark:hidden"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"
-          ></path>
-        </svg>
-        <svg
-          class="w-5 h-5 hidden dark:block"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
-          ></path>
-        </svg>
-      </button>
+      <ThemeToggleBtn />
     </div>
   </div>
 </nav>
-
-<script>
-  const themeToggle = document.getElementById("theme-toggle");
-  themeToggle.addEventListener("click", () => {
-    console.log("Clicked");
-    document.documentElement.classList.toggle("dark");
-    localStorage.theme = document.documentElement.classList.contains("dark")
-      ? "dark"
-      : "light";
-  });
-</script>

--- a/src/components/ThemeToggleBtn.astro
+++ b/src/components/ThemeToggleBtn.astro
@@ -1,0 +1,43 @@
+---
+
+---
+
+<button id="theme-toggle" class="p-2 rounded-lg bg-gray-100 dark:bg-gray-800">
+  <svg class="w-5 h-5 dark:hidden" fill="currentColor" viewBox="0 0 20 20">
+    <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"
+    ></path>
+  </svg>
+  <svg
+    class="w-5 h-5 hidden dark:block"
+    fill="currentColor"
+    viewBox="0 0 20 20"
+  >
+    <path
+      d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z"
+      class="fill-gray-100"></path>
+  </svg>
+</button>
+
+<script>
+  function on_theme_toggle() {
+    document.documentElement.classList.toggle("dark");
+    localStorage.setItem(
+      "theme",
+      document.documentElement.classList.contains("dark") ? "dark" : "light"
+    );
+  }
+
+  function register_toggle_btn() {
+    const themeToggle = document.getElementById("theme-toggle");
+    themeToggle.addEventListener("click", on_theme_toggle);
+    document.addEventListener(
+      "astro:before-swap",
+      () => {
+        themeToggle.removeEventListener("click", on_theme_toggle);
+      },
+      { once: true }
+    );
+  }
+  document.addEventListener("astro:after-swap", register_toggle_btn);
+  register_toggle_btn();
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -34,21 +34,33 @@ const { title } = Astro.props;
     <Footer />
     <script>
       import AOS from "aos";
-      AOS.init({
-        duration: 800,
-        once: true,
-      });
-    </script>
-    <script is:inline>
-      if (
-        localStorage.theme === "dark" ||
-        (!("theme" in localStorage) &&
-          window.matchMedia("(prefers-color-scheme: dark)").matches)
-      ) {
-        document.documentElement.classList.add("dark");
-      } else {
-        document.documentElement.classList.remove("dark");
+      function init_aos() {
+        AOS.init({
+          duration: 800,
+          once: true,
+        });
       }
+      document.addEventListener("astro:after-swap", init_aos);
+      init_aos();
+    </script>
+    <script>
+      function set_theme() {
+        let preferredTheme = localStorage.getItem("theme");
+        if (preferredTheme == null) {
+          if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+            preferredTheme = "dark";
+          } else {
+            preferredTheme = "light";
+          }
+        }
+        if (preferredTheme === "dark") {
+          document.documentElement.classList.add("dark");
+        } else {
+          document.documentElement.classList.remove("dark");
+        }
+      }
+      document.addEventListener("astro:after-swap", set_theme);
+      set_theme();
     </script>
   </body>
 </html>


### PR DESCRIPTION
1. astro bundles all the script tag into one for optimization. to opt-out this feature is:inline directive is used
2. since astro view transition feature is enabled the page is not reload but the contents are only replaced with js. due to this the top-level js are not rerendered. to avoid this we need to add listener for after swap and execute the js.

this is a temp fix. adding the after-swap listener will become annoying when the codebase grows. need to think new solution.